### PR TITLE
Got a fix for the first focus bug.

### DIFF
--- a/jquery.fcbkcomplete.js
+++ b/jquery.fcbkcomplete.js
@@ -108,7 +108,7 @@ jQuery(function($) {
                 complete = $(document.createElement("div"));
                 complete.addClass("facebook-auto");
                 complete.append('<div class="default">' + options.complete_text + "</div>");
-                complete.hover(function() {options.complete_hover = 0;}, function() {options.complete_hover = 1;});
+                complete.hover(function() {complete_hover = 0;}, function() {complete_hover = 1;});
                 
                 feed = $(document.createElement("ul"));
                 feed.attr("id", elemid + "_feed");
@@ -247,7 +247,7 @@ jQuery(function($) {
                 });
 
                 input.blur(function() {
-                    if (options.complete_hover) {
+                    if (complete_hover) {
                       complete.fadeOut("fast");
                     }
                     else {


### PR DESCRIPTION
This commit should fix the first focus bug that is described here: https://github.com/emposha/FCBKcomplete/issues/#issue/36

This bug shows up only the first time that you focus and then blur the input. The problem is caused by the complete_hover variable being incorrectly referenced as options.complete_hover. (It's not an option.) To fix it, I changed the references from options.complete_hover to just simply complete_hover.
