### PR TITLE
Error in illumination (displays "$3")

### DIFF
--- a/jquery.fcbkcomplete.js
+++ b/jquery.fcbkcomplete.js
@@ -187,7 +187,9 @@
             return false;
           }
           //auto expand input
-          input.attr("size", input.val().length + 1);
+          var newsize = input.val().length + 1;
+          if (options.input_min_size > newsize) newsize = options.input_min_size;
+          input.attr("size", newsize);
         });
 
         input.keyup( function(event) {


### PR DESCRIPTION
https://github.com/emposha/FCBKcomplete/issues/74

The "string_regex_adder + options.filter_case" in line 289 seems to result in defective illumination, displaying a "$3" at the end of each entry. Tested with Firefox 5. Surrounding the conditional statement with parentheses seems to fix the problem:
var string_regex = string_regex_adder + (options.filter_case ? "(" + etext + ")(.)" : "(" + etext.toLowerCase() + ")(.)");
