### PR TITLE
Update jquery.fcbkcomplete.js

### DIFF
--- a/jquery.fcbkcomplete.js
+++ b/jquery.fcbkcomplete.js
@@ -240,7 +240,7 @@
             }
           }
 
-          if (event.keyCode != _key.downarrow && event.keyCode != _key.uparrow && event.keyCode!= _key.leftarrow && event.keyCode!= _key.rightarrow && etext.length > options.input_min_size) {
+          if (event.keyCode != _key.downarrow && event.keyCode != _key.uparrow && event.keyCode!= _key.leftarrow && event.keyCode!= _key.rightarrow && etext.length >= options.input_min_size) {
             load_feed(etext);
             complete.children(".default").hide();
             feed.show();


### PR DESCRIPTION
fixed input_min_size behavior.
if user sets input_min_size - he expects exact min size. that's why i've changed '>' to '>='
